### PR TITLE
(fix) Clearing relationships was not applying to the db

### DIFF
--- a/fields/types/relationship/RelationshipType.js
+++ b/fields/types/relationship/RelationshipType.js
@@ -212,43 +212,45 @@ relationship.prototype.inputIsValid = function (data, required, item) {
 /**
  * Updates the value for this field in the item from a data object.
  * Only updates the value if it has changed.
- * Treats an empty string as a null value.
  * If data object does not contain the path field, then leave the field untouched.
- * falsey values such as `null` or an empty string will reset the field
+ * Undefined will reset the field.
  */
 relationship.prototype.updateItem = function (item, data, callback) {
 	if (item.populated(this.path)) {
 		throw new Error('fieldTypes.relationship.updateItem() Error - You cannot update populated relationships.');
 	}
 
-	var value = this.getValueFromData(data);
-	if (value === undefined) {
-		return process.nextTick(callback);
-	}
+	// Grab our old and intended new values.
+	var newVal = this.getValueFromData(data);	// Intended new value.
+	var oldVal = item.get(this.path);	// Current / old value.
 
 	// Are we handling a many relationship or just one value?
 	if (this.many) {
-		var arr = item.get(this.path);
-		var _old = arr.map(function (i) { return String(i); });
-		var _new = value;
-		if (!utils.isArray(_new)) {
-			_new = String(_new || '').split(',');
+		oldVal = oldVal.map(function (i) { return String(i); }); // Map any values to a string
+
+		// Make sure our intended new data is a string array.
+		// This will also ensure an undefined value will be an empty array.
+		if (!utils.isArray(newVal)) {
+			newVal = String(newVal || '').split(',');
 		}
-		_new = _.compact(_new);
+		newVal = _.compact(newVal); // Remove all falsy items from the array.
+
 		// Only update if the lists aren't the same
-		if (!_.isEqual(_old, _new)) {
-			item.set(this.path, _new);
+		if (!_.isEqual(oldVal, newVal)) {
+			item.set(this.path, newVal);
 		}
 	} else {
-		// Ok, it's one value, should I do anything with it?
-		if (value && value !== item.get(this.path)) {
-			// If it's set and has changed, I do.
-			item.set(this.path, value);
-		} else if (!value && item.get(this.path)) {
-			// If it's not set and it was set previously, I need to clear.
+		// Map our values to a string
+		newVal = _.toString(newVal);
+		oldVal = _.toString(oldVal);
+
+		if (newVal && !_.isEqual(newVal, oldVal)) {
+			// We have a new val, and it differs from our stored value.
+			item.set(this.path, newVal);
+		} else if (!newVal && oldVal) {
+			// The new val is undefined and we have an old val - so our intent is to clear it.
 			item.set(this.path, null);
 		}
-		// Otherwise, ignore.
 	}
 	process.nextTick(callback);
 };

--- a/fields/types/relationship/test/type.js
+++ b/fields/types/relationship/test/type.js
@@ -140,19 +140,6 @@ exports.testFieldType = function (List) {
 			});
 		});
 
-		it('should save the provided value with an item object', function (done) {
-			var testItem = new List.model();
-			List.fields.single.updateItem(testItem, { single: relatedItem }, function () {
-				// TODO: We should be testing for errors here
-				testItem.save(function (err, updatedItem) {
-					List.model.findById(updatedItem.id, function (err, persistedData) {
-						demand(String(persistedData.single)).equal(String(relatedItem.id));
-						done();
-					});
-				});
-			});
-		});
-
 		it('should clear the current value when provided null', function (done) {
 			var testItem = new List.model({
 				single: relatedItem.id,
@@ -187,7 +174,7 @@ exports.testFieldType = function (List) {
 			});
 		});
 
-		it('should not clear the current value when data object does not contain the field', function (done) {
+		it('should clear the current value when provided undefined', function (done) {
 			var testItem = new List.model({
 				single: relatedItem.id,
 			});
@@ -195,7 +182,7 @@ exports.testFieldType = function (List) {
 				List.fields.single.updateItem(testItem, {}, function () {
 					testItem.save(function (err, updatedItem) {
 						List.model.findById(updatedItem.id, function (err, persistedData) {
-							demand(String(persistedData.single)).equal(String(relatedItem.id));
+							demand(persistedData.single).be.null();
 							done();
 						});
 					});
@@ -247,7 +234,7 @@ exports.testFieldType = function (List) {
 			});
 		});
 
-		it('should not clear the current values when data object does not contain the field', function (done) {
+		it('should clear the current values when data object does not contain the field', function (done) {
 			var testItem = new List.model({
 				many: [relatedItem.id, relatedItem.id],
 			});
@@ -255,9 +242,7 @@ exports.testFieldType = function (List) {
 				List.fields.many.updateItem(testItem, {}, function () {
 					testItem.save(function (err, updatedItem) {
 						List.model.findById(updatedItem.id, function (err, persistedData) {
-							demand(persistedData.many.length).equal(2);
-							demand(String(persistedData.many[0])).equal(String(relatedItem.id));
-							demand(String(persistedData.many[1])).equal(String(relatedItem.id));
+							demand(persistedData.many.length).equal(0);
 							done();
 						});
 					});


### PR DESCRIPTION
(fix) Relationships were re-saving on every save in admin

<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes



## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

