### PR TITLE
add support for custom buttons from keystone-config

### DIFF
--- a/admin/server/routes/index.js
+++ b/admin/server/routes/index.js
@@ -41,18 +41,21 @@ module.exports = function IndexRoute (req, res) {
 		},
 		userList: UserList.key,
 		version: keystone.version,
-		wysiwyg: { options: {
-			enableImages: keystone.get('wysiwyg images') ? true : false,
-			enableCloudinaryUploads: keystone.get('wysiwyg cloudinary images') ? true : false,
-			enableS3Uploads: keystone.get('wysiwyg s3 images') ? true : false,
-			additionalButtons: keystone.get('wysiwyg additional buttons') || '',
-			additionalPlugins: keystone.get('wysiwyg additional plugins') || '',
-			additionalOptions: keystone.get('wysiwyg additional options') || {},
-			overrideToolbar: keystone.get('wysiwyg override toolbar'),
-			skin: keystone.get('wysiwyg skin') || 'keystone',
-			menubar: keystone.get('wysiwyg menubar'),
-			importcss: keystone.get('wysiwyg importcss') || '',
-		} },
+		wysiwyg: {
+			options: {
+				customButtons: keystone.get('wysiwyg custom buttons') || [],
+				enableImages: keystone.get('wysiwyg images') ? true : false,
+				enableCloudinaryUploads: keystone.get('wysiwyg cloudinary images') ? true : false,
+				enableS3Uploads: keystone.get('wysiwyg s3 images') ? true : false,
+				additionalButtons: keystone.get('wysiwyg additional buttons') || '',
+				additionalPlugins: keystone.get('wysiwyg additional plugins') || '',
+				additionalOptions: keystone.get('wysiwyg additional options') || {},
+				overrideToolbar: keystone.get('wysiwyg override toolbar'),
+				skin: keystone.get('wysiwyg skin') || 'keystone',
+				menubar: keystone.get('wysiwyg menubar'),
+				importcss: keystone.get('wysiwyg importcss') || '',
+			}
+		},
 	};
 	keystoneData.csrf.header[keystone.security.csrf.CSRF_HEADER_KEY] = keystone.security.csrf.getToken(req, res);
 

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -47,6 +47,8 @@ module.exports = Field.create({
 
 		opts.setup = function (editor) {
 			self.editor = editor;
+			self.setupCustomButtons();
+
 			editor.on('change', self.valueChanged);
 			editor.on('focus', self.focusChanged.bind(self, true));
 			editor.on('blur', self.focusChanged.bind(self, false));
@@ -59,12 +61,28 @@ module.exports = Field.create({
 		}
 	},
 
-	removeWysiwyg (state) {
+	removeWysiwyg(state) {
 		removeTinyMCEInstance(tinymce.get(state.id));
 		this.setState({ wysiwygActive: false });
 	},
 
-	componentDidUpdate (prevProps, prevState) {
+	setupCustomButtons() {
+		const buttons = Keystone.options.wysiwyg.customButtons || [];
+
+		for (const button of buttons) {
+			self.editor.addButton(button.name, {
+				icon: button.icon,
+				tooltip: button.tooltip,
+				onclick: function () {
+					if (button.insertContent) {
+						self.editor.insertContent(button.insertContent)
+					}
+				}
+			});
+		}
+	},
+
+	componentDidUpdate(prevProps, prevState) {
 		if (prevState.isCollapsed && !this.state.isCollapsed) {
 			this.initWysiwyg();
 		}


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes
Add support for custom buttons from keystone config

## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

