### PR TITLE
fix typo: wysiwyg.options instead of options.wysiwyg

### DIFF
--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -11,12 +11,12 @@ import evalDependsOn from '../../utils/evalDependsOn';
 
 var lastId = 0;
 
-function getId () {
+function getId() {
 	return 'keystone-html-' + lastId++;
 }
 
 // Workaround for #2834 found here https://github.com/tinymce/tinymce/issues/794#issuecomment-203701329
-function removeTinyMCEInstance (editor) {
+function removeTinyMCEInstance(editor) {
 	var oldLength = tinymce.editors.length;
 	tinymce.remove(editor);
 	if (oldLength === tinymce.editors.length) {
@@ -31,7 +31,7 @@ module.exports = Field.create({
 		type: 'Html',
 	},
 
-	getInitialState () {
+	getInitialState() {
 		return {
 			id: getId(),
 			isFocused: false,
@@ -39,7 +39,7 @@ module.exports = Field.create({
 		};
 	},
 
-	initWysiwyg () {
+	initWysiwyg() {
 		if (!this.props.wysiwyg) return;
 
 		var self = this;
@@ -67,7 +67,7 @@ module.exports = Field.create({
 	},
 
 	setupCustomButtons() {
-		const buttons = Keystone.options.wysiwyg.customButtons || [];
+		const buttons = Keystone.wysiwyg.options.customButtons || [];
 
 		for (const button of buttons) {
 			self.editor.addButton(button.name, {
@@ -98,23 +98,23 @@ module.exports = Field.create({
 		}
 	},
 
-	componentDidMount () {
+	componentDidMount() {
 		this.initWysiwyg();
 	},
 
-	componentWillReceiveProps (nextProps) {
+	componentWillReceiveProps(nextProps) {
 		if (this.editor && this._currentValue !== nextProps.value) {
 			this.editor.setContent(nextProps.value);
 		}
 	},
 
-	focusChanged (focused) {
+	focusChanged(focused) {
 		this.setState({
 			isFocused: focused,
 		});
 	},
 
-	valueChanged  (event) {
+	valueChanged(event) {
 		var content;
 		if (this.editor) {
 			content = this.editor.getContent();
@@ -129,7 +129,7 @@ module.exports = Field.create({
 		});
 	},
 
-	getOptions () {
+	getOptions() {
 		var plugins = ['code', 'link'];
 		var options = Object.assign(
 			{},
@@ -204,7 +204,7 @@ module.exports = Field.create({
 		return opts;
 	},
 
-	renderField () {
+	renderField() {
 		var className = this.state.isFocused ? 'is-focused' : '';
 		var style = {
 			height: this.props.height,
@@ -224,7 +224,7 @@ module.exports = Field.create({
 		);
 	},
 
-	renderValue () {
+	renderValue() {
 		return (
 			<FormInput multiline noedit>
 				{this.props.value}


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes


## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

