### PR TITLE
should be this.editor not self.editor

### DIFF
--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -70,12 +70,12 @@ module.exports = Field.create({
 		const buttons = Keystone.wysiwyg.options.customButtons || [];
 
 		for (const button of buttons) {
-			self.editor.addButton(button.name, {
+			this.editor.addButton(button.name, {
 				icon: button.icon,
 				tooltip: button.tooltip,
 				onclick: function () {
 					if (button.insertContent) {
-						self.editor.insertContent(button.insertContent)
+						this.editor.insertContent(button.insertContent)
 					}
 				}
 			});


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes


## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

