### PR TITLE
add support for custom svg-icons

### DIFF
--- a/admin/server/routes/index.js
+++ b/admin/server/routes/index.js
@@ -4,7 +4,7 @@ var path = require('path');
 
 var templatePath = path.resolve(__dirname, '../templates/index.html');
 
-module.exports = function IndexRoute (req, res) {
+module.exports = function IndexRoute(req, res) {
 	var keystone = req.keystone;
 	var lists = {};
 	_.forEach(keystone.lists, function (list, key) {
@@ -44,6 +44,7 @@ module.exports = function IndexRoute (req, res) {
 		wysiwyg: {
 			options: {
 				customButtons: keystone.get('wysiwyg custom buttons') || [],
+				customIcons: keystone.get('wysiwyg custom icons') || [],
 				enableImages: keystone.get('wysiwyg images') ? true : false,
 				enableCloudinaryUploads: keystone.get('wysiwyg cloudinary images') ? true : false,
 				enableS3Uploads: keystone.get('wysiwyg s3 images') ? true : false,

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -11,12 +11,12 @@ import evalDependsOn from '../../utils/evalDependsOn';
 
 var lastId = 0;
 
-function getId () {
+function getId() {
 	return 'keystone-html-' + lastId++;
 }
 
 // Workaround for #2834 found here https://github.com/tinymce/tinymce/issues/794#issuecomment-203701329
-function removeTinyMCEInstance (editor) {
+function removeTinyMCEInstance(editor) {
 	var oldLength = tinymce.editors.length;
 	tinymce.remove(editor);
 	if (oldLength === tinymce.editors.length) {
@@ -31,7 +31,7 @@ module.exports = Field.create({
 		type: 'Html',
 	},
 
-	getInitialState () {
+	getInitialState() {
 		return {
 			id: getId(),
 			isFocused: false,
@@ -39,7 +39,7 @@ module.exports = Field.create({
 		};
 	},
 
-	initWysiwyg () {
+	initWysiwyg() {
 		if (!this.props.wysiwyg) return;
 
 		var self = this;
@@ -47,6 +47,8 @@ module.exports = Field.create({
 
 		opts.setup = function (editor) {
 			self.editor = editor;
+
+			self.setupCustomIcons();
 			self.setupCustomButtons();
 
 			editor.on('change', self.valueChanged);
@@ -61,12 +63,20 @@ module.exports = Field.create({
 		}
 	},
 
-	removeWysiwyg (state) {
+	removeWysiwyg(state) {
 		removeTinyMCEInstance(tinymce.get(state.id));
 		this.setState({ wysiwygActive: false });
 	},
 
-	setupCustomButtons () {
+	setupCustomIcons() {
+		const icons = Keystone.wysiwyg.options.customIcons || [];
+
+		for (const icon of icons) {
+			this.editor.ui.registry.addIcon(icon.name, icon.svg);
+		}
+	},
+
+	setupCustomButtons() {
 		const buttons = Keystone.wysiwyg.options.customButtons || [];
 
 		for (const button of buttons) {
@@ -82,7 +92,7 @@ module.exports = Field.create({
 		}
 	},
 
-	componentDidUpdate (prevProps, prevState) {
+	componentDidUpdate(prevProps, prevState) {
 		if (prevState.isCollapsed && !this.state.isCollapsed) {
 			this.initWysiwyg();
 		}
@@ -98,23 +108,23 @@ module.exports = Field.create({
 		}
 	},
 
-	componentDidMount () {
+	componentDidMount() {
 		this.initWysiwyg();
 	},
 
-	componentWillReceiveProps (nextProps) {
+	componentWillReceiveProps(nextProps) {
 		if (this.editor && this._currentValue !== nextProps.value) {
 			this.editor.setContent(nextProps.value);
 		}
 	},
 
-	focusChanged (focused) {
+	focusChanged(focused) {
 		this.setState({
 			isFocused: focused,
 		});
 	},
 
-	valueChanged (event) {
+	valueChanged(event) {
 		var content;
 		if (this.editor) {
 			content = this.editor.getContent();
@@ -129,7 +139,7 @@ module.exports = Field.create({
 		});
 	},
 
-	getOptions () {
+	getOptions() {
 		var plugins = ['code', 'link'];
 		var options = Object.assign(
 			{},
@@ -204,7 +214,7 @@ module.exports = Field.create({
 		return opts;
 	},
 
-	renderField () {
+	renderField() {
 		var className = this.state.isFocused ? 'is-focused' : '';
 		var style = {
 			height: this.props.height,
@@ -224,7 +234,7 @@ module.exports = Field.create({
 		);
 	},
 
-	renderValue () {
+	renderValue() {
 		return (
 			<FormInput multiline noedit>
 				{this.props.value}


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes
add support for custom svg icons

## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

