### PR TITLE
remove support for icons. Only in keystone 5

### DIFF
--- a/admin/server/routes/index.js
+++ b/admin/server/routes/index.js
@@ -44,7 +44,6 @@ module.exports = function IndexRoute(req, res) {
 		wysiwyg: {
 			options: {
 				customButtons: keystone.get('wysiwyg custom buttons') || [],
-				customIcons: keystone.get('wysiwyg custom icons') || [],
 				enableImages: keystone.get('wysiwyg images') ? true : false,
 				enableCloudinaryUploads: keystone.get('wysiwyg cloudinary images') ? true : false,
 				enableS3Uploads: keystone.get('wysiwyg s3 images') ? true : false,

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -48,7 +48,6 @@ module.exports = Field.create({
 		opts.setup = function (editor) {
 			self.editor = editor;
 
-			self.setupCustomIcons();
 			self.setupCustomButtons();
 
 			editor.on('change', self.valueChanged);
@@ -66,14 +65,6 @@ module.exports = Field.create({
 	removeWysiwyg(state) {
 		removeTinyMCEInstance(tinymce.get(state.id));
 		this.setState({ wysiwygActive: false });
-	},
-
-	setupCustomIcons() {
-		const icons = Keystone.wysiwyg.options.customIcons || [];
-
-		for (const icon of icons) {
-			this.editor.ui.registry.addIcon(icon.name, icon.svg);
-		}
 	},
 
 	setupCustomButtons() {


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes
Remove support for custom icons

## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

