### PR TITLE
FGL-2335: Add support for showing a duplicate button

### DIFF
--- a/admin/client/App/screens/Item/components/EditFormHeader.js
+++ b/admin/client/App/screens/Item/components/EditFormHeader.js
@@ -131,6 +131,10 @@ export const EditFormHeader = React.createClass({
 	renderInfo () {
 		const buttons = [];
 
+		if (this.props.list.canDuplicate) {
+			buttons.push(this.renderDuplicateButton());
+		}
+
 		if (this.props.list.history) {
 			buttons.push(this.renderHistoryButton());
 			buttons.push(this.renderHistoryPopout());
@@ -190,6 +194,26 @@ export const EditFormHeader = React.createClass({
 		return (
 			<GlyphButton data-e2e-item-create-button="true" color="success" glyph="plus" position="left" {...props}>
 				<ResponsiveText hiddenXS={`New ${singular}`} visibleXS="Create" />
+			</GlyphButton>
+		);
+	},
+	renderDuplicateButton () {
+		const { canDuplicate, path, singular } = this.props.list;
+		const { id } = this.props.data;
+
+		if (!canDuplicate || !id) return null;
+
+		return (
+			<GlyphButton
+				color="default"
+				glyph="versions"
+				position="left"
+				style={{ marginRight: '4px' }}
+				href={`${Keystone.adminPath}/${path}/duplicate/${id}`}>
+				<ResponsiveText
+					hiddenXS={`Duplicate ${singular}`}
+					visibleXS='Duplicate'
+				/>
 			</GlyphButton>
 		);
 	},

--- a/lib/list.js
+++ b/lib/list.js
@@ -24,6 +24,10 @@ module.exports = function (keystone) {
 			searchUsesTextIndex: false,
 			defaultSort: '__default__',
 			defaultColumns: '__name__',
+
+			// CF Custom,
+			// Shows duplicate button in header of elements edit page
+			canDuplicate: false,
 		};
 
 		// initialFields values are initialised on demand by the getter

--- a/lib/list/getOptions.js
+++ b/lib/list/getOptions.js
@@ -7,6 +7,7 @@ function getOptions () {
 	var ops = {
 		autocreate: this.options.autocreate,
 		autokey: this.autokey,
+		canDuplicate: this.options.canDuplicate,
 		defaultColumns: this.options.defaultColumns,
 		defaultSort: this.options.defaultSort,
 		fields: {},


### PR DESCRIPTION
By adding "canDuplicate: true" to a List defintion, a Duplicate {entityName} button will show up redirecting the user to /keystone/{entityName}/duplicate/{idToBeDuplicated}. This can then be implemented in the users Keystone implementation.
